### PR TITLE
Redis integer casted to string fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.lando.dist.yml
+++ b/.lando.dist.yml
@@ -1,0 +1,28 @@
+name: uf-cache
+
+services:
+  appserver:
+    type: php:7.4
+    via: cli
+    xdebug: "debug,develop,coverage"
+    composer_version: '2-latest'
+
+  # Redis cache
+  redis-cache:
+    type: redis:6
+
+  # Memcached cache
+  memcached-cache:
+    type: memcached:1
+
+tooling:
+  composer:
+    service: appserver
+    cmd: composer
+  phpunit:
+    service: appserver
+    description: "Run PHP Unit tests"
+    cmd: vendor/bin/phpunit
+  redis-cli:
+    service: redis-cache
+    description: "Redis cache CLI"

--- a/.php_cs
+++ b/.php_cs
@@ -3,7 +3,7 @@
 $header = 'UserFrosting Cache (http://www.userfrosting.com)
 
 @link      https://github.com/userfrosting/cache
-@copyright Copyright (c) 2013-2019 Alexander Weissman
+@copyright Copyright (c) 2013-2021 Alexander Weissman
 @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)';
 
 $rules = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Fix for integers being cast to strings with Redis store ([#8])
+
 ## [4.4.2]
 - Replaced Travis with GitHub Action for build
 - Upgrade deprecation in tests
@@ -46,3 +49,4 @@ Initial release
 [4.1.1]: https://github.com/userfrosting/cache/compare/4.1.0...4.1.1
 [#1]: https://github.com/userfrosting/cache/issues/1
 [#5]: https://github.com/userfrosting/cache/issues/5
+[#8]: https://github.com/userfrosting/cache/issues/8

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2019 by Alexander Weissman (https://alexanderweissman.com)
+Copyright (c) 2013-2021 by Alexander Weissman (https://alexanderweissman.com)
 
 UserFrosting is 100% free and open-source.
 

--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -16,7 +16,7 @@ In addition:
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
  ```

--- a/src/ArrayStore.php
+++ b/src/ArrayStore.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/src/ArrayStore.php
+++ b/src/ArrayStore.php
@@ -10,10 +10,10 @@
 
 namespace UserFrosting\Cache;
 
-use Illuminate\Cache\CacheManager;
 use Illuminate\Config\Repository;
 use Illuminate\Container\Container;
-use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Cache\Repository as CacheRepositoryContract;
+use UserFrosting\Cache\Patch\Redis\CacheManager;
 
 /**
  * ArrayStore Class.
@@ -72,7 +72,7 @@ class ArrayStore
     /**
      * Return the store instance from the Laravel CacheManager.
      *
-     * @return Store Laravel Cache instance
+     * @return CacheRepositoryContract Laravel Cache instance
      */
     public function instance()
     {

--- a/src/Driver/FileTagSet.php
+++ b/src/Driver/FileTagSet.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/src/Driver/TaggableFileStore.php
+++ b/src/Driver/TaggableFileStore.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/src/Driver/TaggedFileCache.php
+++ b/src/Driver/TaggedFileCache.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/src/FileStore.php
+++ b/src/FileStore.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/src/MemcachedStore.php
+++ b/src/MemcachedStore.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/src/Patch/README.md
+++ b/src/Patch/README.md
@@ -1,0 +1,1 @@
+Home to patches for upstream issues.

--- a/src/Patch/Redis/CacheManager.php
+++ b/src/Patch/Redis/CacheManager.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * UserFrosting Cache (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/cache
+ * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
+ */
+
+namespace UserFrosting\Cache\Patch\Redis;
+
+use Illuminate\Cache\CacheManager as UpstreamCacheManager;
+use UserFrosting\Cache\Patch\Redis\RedisStore;
+
+/**
+ * Permits usage of patched `RedisStore`.
+ * See https://github.com/userfrosting/cache/issues/8
+ */
+class CacheManager extends UpstreamCacheManager
+{
+    protected function createRedisDriver(array $config)
+    {
+        $redis = $this->app['redis'];
+
+        $connection = $config['connection'] ?? 'default';
+
+        return $this->repository(new RedisStore($redis, $this->getPrefix($config), $connection));
+    }
+}

--- a/src/Patch/Redis/CacheManager.php
+++ b/src/Patch/Redis/CacheManager.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/src/Patch/Redis/CacheManager.php
+++ b/src/Patch/Redis/CacheManager.php
@@ -11,11 +11,10 @@
 namespace UserFrosting\Cache\Patch\Redis;
 
 use Illuminate\Cache\CacheManager as UpstreamCacheManager;
-use UserFrosting\Cache\Patch\Redis\RedisStore;
 
 /**
  * Permits usage of patched `RedisStore`.
- * See https://github.com/userfrosting/cache/issues/8
+ * See https://github.com/userfrosting/cache/issues/8.
  */
 class CacheManager extends UpstreamCacheManager
 {

--- a/src/Patch/Redis/RedisStore.php
+++ b/src/Patch/Redis/RedisStore.php
@@ -14,7 +14,7 @@ use Illuminate\Cache\RedisStore as UpstreamRedisStore;
 
 /**
  * A patched `RedisStore` which resolves value an integer serialization bug.
- * See https://github.com/userfrosting/cache/issues/8
+ * See https://github.com/userfrosting/cache/issues/8.
  */
 class RedisStore extends UpstreamRedisStore
 {

--- a/src/Patch/Redis/RedisStore.php
+++ b/src/Patch/Redis/RedisStore.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/src/Patch/Redis/RedisStore.php
+++ b/src/Patch/Redis/RedisStore.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * UserFrosting Cache (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/cache
+ * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
+ */
+
+namespace UserFrosting\Cache\Patch\Redis;
+
+use Illuminate\Cache\RedisStore as UpstreamRedisStore;
+
+/**
+ * A patched `RedisStore` which resolves value an integer serialization bug.
+ * See https://github.com/userfrosting/cache/issues/8
+ */
+class RedisStore extends UpstreamRedisStore
+{
+    /** {@inheritdoc} */
+    protected function serialize($value)
+    {
+        return serialize($value);
+    }
+
+    /** {@inheritdoc} */
+    protected function unserialize($value)
+    {
+        return unserialize($value);
+    }
+}

--- a/src/RedisStore.php
+++ b/src/RedisStore.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/src/TaggableFileStore.php
+++ b/src/TaggableFileStore.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/tests/MemcachedStoreTest.php
+++ b/tests/MemcachedStoreTest.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/tests/MemcachedStoreTest.php
+++ b/tests/MemcachedStoreTest.php
@@ -11,7 +11,6 @@
 namespace UserFrosting\Cache\Tests;
 
 use UserFrosting\Cache\MemcachedStore;
-use UserFrosting\Cache\Tests\StoreTestCase;
 
 /**
  * @requires extension Memcached
@@ -27,6 +26,7 @@ class MemcachedStoreTest extends StoreTestCase
             $config['host'] = 'memcached-cache';
         }
         $cacheStore = new MemcachedStore($config);
+
         return $cacheStore->instance();
     }
 

--- a/tests/MemcachedStoreTest.php
+++ b/tests/MemcachedStoreTest.php
@@ -10,22 +10,32 @@
 
 namespace UserFrosting\Cache\Tests;
 
-use PHPUnit\Framework\TestCase;
 use UserFrosting\Cache\MemcachedStore;
+use UserFrosting\Cache\Tests\StoreTestCase;
 
 /**
  * @requires extension Memcached
  */
-class MemcachedTest extends TestCase
+class MemcachedStoreTest extends StoreTestCase
 {
+    /** {@inheritdoc} */
+    protected function createStore()
+    {
+        // Create $cache with default config in CI, and tweaked in Lando
+        $config = [];
+        if (getenv('LANDO') === 'ON') {
+            $config['host'] = 'memcached-cache';
+        }
+        $cacheStore = new MemcachedStore($config);
+        return $cacheStore->instance();
+    }
+
     /**
      * Test memcached store.
      */
     public function testMemcachedStore()
     {
-        // Create the $cache object using the default memcache server config
-        $cacheStore = new MemcachedStore();
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Store "foo" and try to read it
         $cache->forever('foo', 'memcached bar');
@@ -34,9 +44,7 @@ class MemcachedTest extends TestCase
 
     public function testMemcachedStorePersistence()
     {
-        // Create the $cache object using the default memcache server config
-        $cacheStore = new MemcachedStore();
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Doesn't store anything, just tried to read the last one
         $this->assertEquals('memcached bar', $cache->get('foo'));
@@ -44,9 +52,7 @@ class MemcachedTest extends TestCase
 
     public function testMultipleMemcachedStore()
     {
-        // Create two $cache object
-        $cacheStore = new MemcachedStore();
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Store stuff in first
         $cache->tags('global')->forever('test', '1234');
@@ -68,9 +74,7 @@ class MemcachedTest extends TestCase
 
     public function testMultipleMemcachedStoreWithTags()
     {
-        // Create two $cache object
-        $cacheStore = new MemcachedStore();
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Store stuff in first
         $cache->tags(['foo', 'red'])->forever('bar', 'red');
@@ -88,9 +92,7 @@ class MemcachedTest extends TestCase
 
     public function testTagsFlush()
     {
-        // Get store
-        $cacheStore = new MemcachedStore();
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Start by not using tags
         $cache->put('test', '123', 60);

--- a/tests/RedisStoreTest.php
+++ b/tests/RedisStoreTest.php
@@ -11,7 +11,6 @@
 namespace UserFrosting\Cache\Tests;
 
 use UserFrosting\Cache\RedisStore;
-use UserFrosting\Cache\Tests\StoreTestCase;
 
 /**
  * @requires extension redis
@@ -27,6 +26,7 @@ class RedisStoreTest extends StoreTestCase
             $config['host'] = 'redis-cache';
         }
         $cacheStore = new RedisStore($config);
+
         return $cacheStore->instance();
     }
 

--- a/tests/RedisStoreTest.php
+++ b/tests/RedisStoreTest.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/tests/RedisStoreTest.php
+++ b/tests/RedisStoreTest.php
@@ -10,22 +10,32 @@
 
 namespace UserFrosting\Cache\Tests;
 
-use PHPUnit\Framework\TestCase;
 use UserFrosting\Cache\RedisStore;
+use UserFrosting\Cache\Tests\StoreTestCase;
 
 /**
  * @requires extension redis
  */
-class RedisTest extends TestCase
+class RedisStoreTest extends StoreTestCase
 {
+    /** {@inheritdoc} */
+    protected function createStore()
+    {
+        // Create $cache with default config in CI, and tweaked in Lando
+        $config = [];
+        if (getenv('LANDO') === 'ON') {
+            $config['host'] = 'redis-cache';
+        }
+        $cacheStore = new RedisStore($config);
+        return $cacheStore->instance();
+    }
+
     /**
      * Test redis store.
      */
     public function testRedisStore()
     {
-        // Create the $cache object using the default memcache server config
-        $cacheStore = new RedisStore();
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Store "foo" and try to read it
         $cache->forever('foo', 'Redis bar');
@@ -34,9 +44,7 @@ class RedisTest extends TestCase
 
     public function testRedisStorePersistence()
     {
-        // Create the $cache object using the default memcache server config
-        $cacheStore = new RedisStore();
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Doesn't store anything, just tried to read the last one
         $this->assertEquals('Redis bar', $cache->get('foo'));
@@ -44,9 +52,7 @@ class RedisTest extends TestCase
 
     public function testMultipleRedisStore()
     {
-        // Create two $cache object
-        $cacheStore = new RedisStore();
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Store stuff in first
         $cache->tags('global')->forever('test', '1234');
@@ -68,9 +74,7 @@ class RedisTest extends TestCase
 
     public function testTagsFlush()
     {
-        // Get store
-        $cacheStore = new RedisStore();
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Start by not using tags
         $cache->put('test', '123', 60);

--- a/tests/StoreTestCase.php
+++ b/tests/StoreTestCase.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/tests/StoreTestCase.php
+++ b/tests/StoreTestCase.php
@@ -36,15 +36,15 @@ abstract class StoreTestCase extends TestCase
         $this->assertSame(999, $cache->get('string'));
 
         // array filled
-        $cache->put('array_filled', [ 'a', 'b', 'c', 1, 2, 3 ]);
+        $cache->put('array_filled', ['a', 'b', 'c', 1, 2, 3]);
         $this->assertSame(null, $cache->get('array'));
-        
+
         // array empty
         $cache->put('array_empty', []);
         $this->assertSame(null, $cache->get('array'));
-        
+
         // object
-        $cache->put('object', (object)[]);
+        $cache->put('object', (object) []);
         $this->assertSame(null, $cache->get('array'));
     }
 }

--- a/tests/StoreTestCase.php
+++ b/tests/StoreTestCase.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * UserFrosting Cache (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/cache
+ * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
+ */
+
+namespace UserFrosting\Cache\Tests;
+
+use Illuminate\Contracts\Cache\Repository as CacheRepositoryContract;
+use PHPUnit\Framework\TestCase;
+
+abstract class StoreTestCase extends TestCase
+{
+    /**
+     * @return CacheRepositoryContract Laravel Cache instance
+     */
+    abstract protected function createStore();
+
+    /**
+     * Ensure consistent behaviors across all cache providers.
+     */
+    public function testPutValueHandling()
+    {
+        $cache = $this->createStore();
+
+        // string
+        $cache->put('string', 'foobar');
+        $this->assertSame('foobar', $cache->get('string'));
+
+        // int
+        $cache->put('string', 999);
+        $this->assertSame(999, $cache->get('string'));
+
+        // array filled
+        $cache->put('array_filled', [ 'a', 'b', 'c', 1, 2, 3 ]);
+        $this->assertSame(null, $cache->get('array'));
+        
+        // array empty
+        $cache->put('array_empty', []);
+        $this->assertSame(null, $cache->get('array'));
+        
+        // object
+        $cache->put('object', (object)[]);
+        $this->assertSame(null, $cache->get('array'));
+    }
+}

--- a/tests/TaggableFileDriverTest.php
+++ b/tests/TaggableFileDriverTest.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/tests/TaggableFileStoreTest.php
+++ b/tests/TaggableFileStoreTest.php
@@ -4,7 +4,7 @@
  * UserFrosting Cache (http://www.userfrosting.com)
  *
  * @link      https://github.com/userfrosting/cache
- * @copyright Copyright (c) 2013-2019 Alexander Weissman
+ * @copyright Copyright (c) 2013-2021 Alexander Weissman
  * @license   https://github.com/userfrosting/cache/blob/master/LICENSE.md (MIT License)
  */
 

--- a/tests/TaggableFileStoreTest.php
+++ b/tests/TaggableFileStoreTest.php
@@ -10,10 +10,10 @@
 
 namespace UserFrosting\Cache\Tests;
 
-use PHPUnit\Framework\TestCase;
 use UserFrosting\Cache\TaggableFileStore;
+use UserFrosting\Cache\Tests\StoreTestCase;
 
-class TaggableFileStoreTest extends TestCase
+class TaggableFileStoreTest extends StoreTestCase
 {
     public $storage;
 
@@ -22,14 +22,20 @@ class TaggableFileStoreTest extends TestCase
         $this->storage = './tests/cache/TaggableFileStore';
     }
 
+    /** {@inheritdoc} */
+    protected function createStore()
+    {
+        // Create the $cache object
+        $cacheStore = new TaggableFileStore($this->storage);
+        return $cacheStore->instance();
+    }
+
     /**
      * Test file store.
      */
     public function testTaggableFileStore()
     {
-        // Create the $cache object
-        $cacheStore = new TaggableFileStore($this->storage);
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Store "foo" and try to read it
         $cache->forever('foo', 'bar');
@@ -38,9 +44,7 @@ class TaggableFileStoreTest extends TestCase
 
     public function TaggableFileStorePersistence()
     {
-        // Create the $cache object
-        $cacheStore = new TaggableFileStore($this->storage);
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Doesn't store anything, just tried to read the last one
         $this->assertEquals('bar', $cache->get('foo'));
@@ -48,9 +52,7 @@ class TaggableFileStoreTest extends TestCase
 
     public function testMultipleTaggableFileStore()
     {
-        // Create two $cache object
-        $cacheStore = new TaggableFileStore($this->storage);
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Store stuff in first
         $cache->tags('global')->forever('test', '1234');
@@ -72,9 +74,7 @@ class TaggableFileStoreTest extends TestCase
 
     public function testMultipleTaggableFileStoreWithTags()
     {
-        // Create two $cache object
-        $cacheStore = new TaggableFileStore($this->storage);
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Store stuff in first
         $cache->tags(['foo', 'red'])->forever('bar', 'red');
@@ -92,9 +92,7 @@ class TaggableFileStoreTest extends TestCase
 
     public function testTagsFlush()
     {
-        // Get store
-        $cacheStore = new TaggableFileStore($this->storage);
-        $cache = $cacheStore->instance();
+        $cache = $this->createStore();
 
         // Start by not using tags
         $cache->put('test', '123', 60);

--- a/tests/TaggableFileStoreTest.php
+++ b/tests/TaggableFileStoreTest.php
@@ -11,7 +11,6 @@
 namespace UserFrosting\Cache\Tests;
 
 use UserFrosting\Cache\TaggableFileStore;
-use UserFrosting\Cache\Tests\StoreTestCase;
 
 class TaggableFileStoreTest extends StoreTestCase
 {
@@ -27,6 +26,7 @@ class TaggableFileStoreTest extends StoreTestCase
     {
         // Create the $cache object
         $cacheStore = new TaggableFileStore($this->storage);
+
         return $cacheStore->instance();
     }
 


### PR DESCRIPTION
This adds a patch to ensure integers aren't cast to strings by the Redis store (bug lies in Laravel).

As part of this I have also added tests to ensure consistency in value handling across all stores. To aid local development, I have added Lando (with tweaks in tests to handle Memcached and Redis living on different hosts).